### PR TITLE
Allow self defined directories for site menu

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,14 @@
   <h3 class="main-menu mr-3">
     <a href="{{ .Site.BaseURL }}">Home</a>
   </h3>
+  {{ if not .Site.Params.disableBlog }}
   <h3 class="main-menu mr-3">
     <a href="{{ `blog` | relURL }}">Blog</a>
   </h3>
+  {{ end }}
+  {{ range .Site.Params.menu.list }}
+  <h3 class="main-menu mr-3">
+    <a href="{{ .dir | relURL }}">{{ .label }}</a>
+  </h3>
+  {{ end }}
 </div>


### PR DESCRIPTION
Current implementation limits the type of content and title labeling allowed for use. With this patch, anyone can add their own labels and directories while still leveraging the same blog style partial format for the single page.

Also added the ability to `disableBlog` instead of removing it entirely to prevent breaking existing themes (they are still enabled by default unless specified otherwise.

Testing:
Manually tested this on my device with the `exampleSite` by changing up the `config.toml` and seeing it work as intended.