### PR TITLE
fix: make mainTheme switchable by clicking when singlePage

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
   {{ if .Site.Params.theme.singlePage }}
   <i
 class="fas fa-sun theme-toggle text-blue-500 hover:text-blue-700 dark:text-yellow-300 dark:hover:text-yellow-500 cursor-pointer text-lg mr-9 sm:mr-0"
-onclick="lightDark(this)"
+onclick="toggleTheme()"
 ></i>
 {{ partial "toggleTheme.html" . }}
 {{ end }}


### PR DESCRIPTION
Hey!
Thanks for this project!
I've noticed that when using your theme in singlePage mode, dark and light are managed on the footer level. But it's not working for me. After adding this fix, everything is fine