### PR TITLE
Updated font awesome icons to v7.0.0

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,8 +15,8 @@
   <link rel="icon" href="{{ `favicon.ico` | relURL }}" type="image/x-icon" />
   <link
     rel="stylesheet"
-    href="https://use.fontawesome.com/releases/v5.15.2/css/all.css"
-    integrity="sha384-vSIIfh2YWi9wW0r9iZe7RJPrKwp6bG+s9QZMoITbCckVJqGCCRhc+ccxNcdpHuYu"
+    href="https://use.fontawesome.com/releases/v7.0.0/css/all.css"
+    integrity="sha384-tGBVFh2h9Zcme3k9gJLbGqDpD+jRd419j/6N32rharcTZa1X6xgxug6pFMGonjxU"
     crossorigin="anonymous"
   />
   <link


### PR DESCRIPTION
This pr updates the font awesome icons stylesheet from v5.15.2 to v7.0.0 that contains more icons, like the Mastodon one.